### PR TITLE
add openssh-client into install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
 FROM golang:1.8.3-alpine
 
+# To use as custom-build docker images, 
+# container image must have installed following tools: 
+#  git, ssh, tar, gzip, ca-certificates
+# https://circleci.com/docs/2.0/custom-images/
 RUN set -x \
     && apk add --no-cache \
     git \
-    build-base \
+    openssh-client \
     tar \
     gzip \
+    ca-certificates \
+    build-base \
     curl \
     py-pip
 


### PR DESCRIPTION
To use custom-built docker images from CircleCI build, following packages must installed.

- git
- ssh
- tar
- gzip
- ca-certificates

https://circleci.com/docs/2.0/custom-images/#required-tools-for-primary-containers

So I added ca-certificates into install packages.